### PR TITLE
open past entries

### DIFF
--- a/techlab/src/app/page.js
+++ b/techlab/src/app/page.js
@@ -11,6 +11,7 @@ export default function Home() {
   const [history, setHistory] = useState([]);
   const [jsonTree, setJsonTree] = useState(null);
   const [status, setStatus] = useState("idle");
+  const [selectedIndex, setSelectedIndex] = useState(null);
 
   const handleSubmit = async (userInput) => {
     const diagramPrompt = `
@@ -73,14 +74,35 @@ export default function Home() {
 
   return (
     <div className="flex">
-      <Sidebar history={history} setHistory={setHistory} />
+      <Sidebar 
+        history={history}
+        setHistory={setHistory}
+        selectedIndex={selectedIndex}
+        setSelectedIndex={setSelectedIndex}
+        onSelect={(item, index) => {
+          try {
+            const parsed = JSON.parse(
+              item.response.trim().replace(/^```json\n/, "").replace(/```$/, "").trim()
+            );
+            setJsonTree(parsed);
+            setResponse(item.response);
+            setStatus("done");
+            setSelectedIndex(index);
+          } catch (e) {
+            console.warn("❌ Failed to parse saved JSON:", e);
+            setJsonTree(null);
+            setStatus("error");
+          }
+        }}
+      />
       <main className="flex-1 p-6 max-w-screen-lg mx-auto">
         <InputBox onSubmit={handleSubmit} onStartRequest={() => {
           setStatus("loading");
           setResponse(""); // clear old response
         }} />
+        {/* Status messages */}
         <ResponseView response={response} status={status} />
-        {jsonTree && console.log("🌳 Ready to render MindMapView:", jsonTree)}
+        {/* Mind map appears once JSON tree is parsed */}
         {jsonTree && <MindMapView jsonTree={jsonTree} />}
       </main>
     </div>

--- a/techlab/src/components/ResponseView.jsx
+++ b/techlab/src/components/ResponseView.jsx
@@ -7,10 +7,10 @@ export default function ResponseView({ response, status }) {
     displayText = "Enter a prompt and click Send to get started.";
   } else if (status === "loading") {
     displayText = "Awaiting Gemini response...";
-  } else if (status === "done") {
-    displayText = response;
   } else if (status === "error") {
     displayText = "Encountered error.";
+  } else if (status === "done") {
+    displayText = response;
   }
 
   return (

--- a/techlab/src/components/Sidebar.jsx
+++ b/techlab/src/components/Sidebar.jsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 
-export default function Sidebar({ history, setHistory }) {
+export default function Sidebar({ history, setHistory, onSelect, selectedIndex }) {
   const [items, setItems] = useState([]);
 
   useEffect(() => {
@@ -14,30 +14,38 @@ export default function Sidebar({ history, setHistory }) {
     const updated = items.filter((_, i) => i !== indexToDelete);
     setItems(updated);
     localStorage.setItem("gemini-history", JSON.stringify(updated));
-    setHistory(updated); // inform parent
+    setHistory(updated);
   };
 
   return (
     <aside className="w-64 border-r p-4 h-screen overflow-y-auto">
+      {/* Sidebar Header */}
       <h2 className="font-bold text-lg mb-4">History</h2>
+      {/* History Items */}
       {items.length === 0 ? (
         <p className="text-gray-500">No history yet.</p>
       ) : (
         <ul className="space-y-2">
+          {/* Render each history item */}
           {items.map((item, i) => (
             <li
               key={i}
-              className="bg-gray-100 p-2 rounded text-sm flex justify-between items-start"
+              onClick={() => onSelect(item, i)}
+              className={`p-2 rounded text-sm flex justify-between items-start cursor-pointer hover:bg-gray-200 ${
+                i === selectedIndex ? "bg-blue-100 border border-blue-300" : "bg-gray-100"
+              }`}
             >
+              {/* Text content for the history item */}
               <div className="flex-1 overflow-hidden">
                 <div className="font-medium truncate">{item.prompt}</div>
                 <div className="text-xs text-gray-600 line-clamp-2">
                   {item.response}
                 </div>
               </div>
+              {/* Delete button for this entry */}
               <button
                 className="text-red-500 text-xs ml-2"
-                onClick={() => deleteItem(i)}
+                onClick={(e) => { deleteItem(i) }}
               >
                 ✕
               </button>


### PR DESCRIPTION
Add ability to open past entries and highlight the currently selected item in the sidebar. Users can now click history items to reload their diagrams.